### PR TITLE
Opened port 443 for https and prepared redirection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/letsencrypt
 COPY ./src ./usr/share/nginx/html
 
 EXPOSE 80
+EXPOSE 443
 
 #ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;", "certbot", "--nginx", "--non-interactive", "--agree-tos", "--domains", "xmas.algosup.com", "--email", "franck.jeannin@algosup.com;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,10 @@
 http {
+    #Redirect http to https
+    #server {
+    #    listen 80;
+    #    server_name xmas.algosup.com;
+    #    return 301 https://xmas.algosup.com$request_uri;
+    #}
     server {
         listen      80;
 


### PR DESCRIPTION
Port 443 is open and ready for https.
Once checked if it is working properly, the commented code in the nginx.conf file will redirect all http traffic to https.